### PR TITLE
Documentation Rewrite

### DIFF
--- a/docs/creating-content.md
+++ b/docs/creating-content.md
@@ -163,7 +163,7 @@ Check out our [Cookbook][] for some tips and code snippets that will help you us
 [MarkdownExtra]: https://michelf.ca/projects/php-markdown/extra/
 [Cookbook]: {{ site.github.url }}/cookbook/
 [CookbookBlogging]: {{ site.github.url }}/cookbook/#BloggingWithPico
-[Theming]: {{ site.github.url }/docs/theming
+[Theming]: {{ site.github.url }}/docs/theming
 
 {% comment %}
 

--- a/docs/creating-content.md
+++ b/docs/creating-content.md
@@ -7,19 +7,26 @@ description: |
   This guide will teach you the basics of these formatting syntaxes<br />
   and how they relate to Pico.
 toc:
-  downloading-and-installing-pico:
-    _title: Downloading and Installing Pico
-    developer-instructions: Developer Instructions
-  url-rewriting:
-    _title: URL Rewriting
-    apache: Apache
-    nginx: Nginx
-  configuring-pico: Configuring Pico
+  simple-but-elegant-content-management:
+    _title: Simple But Elegant Content Management
+    the-content-folder: The Content Folder
+    all-about-urls: All About URLs
+  yaml-and-markdown:
+    _title: YAML and Markdown
+    yaml---yay--a-metadata-lesson: YAML - Yay, A Metadata Lesson
+    markdown---Because-why-mark--up--: Markdown - Because Why Mark *Up*?
+    variable-variables: Variable Variables
+  let-s-get-started:
+    _title: Let's Get Started
+    somewhere-to-land: Somewhere to Land
+    404-heading-not-found: 404 Heading Not Found
+    images--downloads--and-other-assets: Images, Downloads, and Other Assets
+    to-blog-or-not-to-blog: To Blog or Not to Blog
 nav-url: /docs/
 
 ---
 
-## Simple but Elegant Content Management
+## Simple But Elegant Content Management
 
 Pico's flat file nature is a simple approach to content management.  Pico has no dashboard or admin panel.  There's no clunky interface for creating posts or pages.
 
@@ -29,88 +36,17 @@ Pico is simple: You just create a file and write.
 
 ### The Content Folder
 
-When you first set up Pico, you'll notice you have a `content-sample` folder in your Pico root directory.  This folder provides a set of basic sample pages for testing Pico.  It also includes [Pico's inline Readme][InlineReadme], a simple, quick-start reference to using Pico.  When you're ready to create your own content, create a `content` folder in Pico's root directory.  There's no need to remove the `content-sample` folder, or to reconfigure Pico.  Pico will automatically switch to using the `content` folder if it exists.
+When you first set up Pico, you'll notice you have a `content-sample` folder in your Pico root directory.  This folder provides a set of basic sample pages for testing Pico.  It also includes [Pico's inline Readme][InlineReadme], a simple, quick-start reference to using Pico.  When you're ready to create your own content, create a `content` folder in Pico's root directory.  There's no need to remove the `content-sample` folder, or to reconfigure Pico.  Pico will automatically switch to using the `content` folder if it exists and contains an `index.md` file.
 
-### All about URLs
+### All About URLs
 
-## YAML and Markdown
+What if you want to organize your content int subfolders, within the `content` folder?  Pico makes it easy to do just that.  If you were to create a file at `content/subfolder/page.md`, you'd be able to access it at `http://example.com/subfolder/page` (or `http://example.com/?subfolder/page` if you don't have url-rewriting enabled).
 
-[YAML][] and [Markdown][] are a common pair in today's world.  YAML provides an easy to understand syntax for your pages' metadata while Markdown provides easy, plain-text formatting of your content.  The pair make a great combination, and once you learn them you'll find it hard to disagree.
+But Pico lets you take it a step further.  What if you wanted a page at `http://example.com/subfolder/`?  To do this, you'd simply create your page at `content/subfolder/index.md` and Pico will offer it as the landing page for that folder.
 
-* possibly due to the popularity of Jekyll... need a better reason than that.
+One thing to kep in mind though is if you create a folder, you won't be able to access a page with the same name as that folder.  For example, if you have a `content/news/` folder, Pico will direct visitors there instead of to `content/news.md`.
 
-### YAML - Yay, A Metadata Lesson
-
-Writing your metadata in YAML is as easy as writing it out.  Each of your content files in Pico will begin with a "YAML Header".  It will look something like this:
-
-```
----
-Title: Welcome
-Description: This description will go in the meta description tag
-Author: Joe Bloggs
-Date: 2013/01/01
-Robots: noindex,nofollow
-Template: index
----
-```
-
-* Date format?  Update Example?
-
-Simple, huh?  And it gets better too.  These are all the variables that Pico supports by default, but none of them are *required* for your page to work.  The only "required" item on the list above is "Title", but only because Pico's Default Theme uses the page Title in order to link to it.
-
-Each of these metadata fields are utilized by your Pico theme, and some themes may add or require additional fields in order to function.
-
-* Needs more depth.  Reference About page and expand on examples.  Link to cookbook?
-
-### Markdown - Because Why Mark *Up*?
-
-```
-### Text File Markup
-
-Text files are marked up using [Markdown][] and [Markdown Extra][MarkdownExtra]. They can also contain regular HTML.
-
-At the top of text files you can place a block comment and specify certain meta attributes of the page using [YAML][] (the "YAML header"). For example:
-
-
-These values will be contained in the `{% raw %}{{ meta }}{% endraw %}` variable in themes (see below).
-
-There are also certain variables that you can use in your text files:
-
-* `%site_title%` - The title of your Pico site
-* `%base_url%` - The URL to your Pico site; internal links can be specified using `%base_url%?sub/page`
-* `%theme_url%` - The URL to the currently used theme
-* `%meta.*%` - Access any meta variable of the current page, e.g. `%meta.author%` is replaced with `Joe Bloggs`
-```
-
-## Let's Get Started
-
-### Somewhere to Land
-
-The first page you'll want to create is your "index" or "landing page".  This is the file that will be loaded when a user visits the `base_url` of your Pico site.  Start by creating a blank file named `index.md` in the `content` folder.  In the previous section, we discussed how to use YAML and Markdown to create your content.  Use what you've learned to create a landing page worth visiting!
-
-### 404 Heading Not found
-
-```
-If a file cannot be found, the file `content/404.md` will be shown. You can add `404.md` files to any directory. So, for example, if you wanted to use a special error page for your blog, you could simply create `content/blog/404.md`.
-
-```
-
-### Images, Downloads, and Other Assets
-
-```
-As a common practice, we recommend you to separate your contents and assets (like images, downloads, etc.). We even deny access to your `content` directory by default. If you want to use some assets (e.g. a image) in one of your content files, you should create an `assets` folder in Pico's root directory and upload your assets there. You can then access them in your markdown using `%base_url%/assets/` for example: `![Image Title](%base_url%/assets/image.png)`
-```
-
-* provide empty assets folder?
-
-### To Blog or Not to Blog
-
-[InlineReadme]: needs-url
----
-
-## Creating Content (All about URL's)
-
-If you create a folder within the content folder (e.g. `content/sub`) and put an `index.md` inside it, you can access that folder at the URL `http://example.com/?sub`. If you want another page within the sub folder, simply create a text file with the corresponding name and you will be able to access it (e.g. `content/sub/page.md` is accessible from the URL `http://example.com/?sub/page`). Below we've shown some examples of locations and their corresponding URLs:
+Still having trouble wrapping your head around these URLs?  Here's a table with some more examples:
 
 <table style="width: 100%; max-width: 40em;">
     <thead>
@@ -125,25 +61,115 @@ If you create a folder within the content folder (e.g. `content/sub`) and put an
             <td>/</td>
         </tr>
         <tr>
-            <td>content/sub.md</td>
-            <td><del>?sub</del> (not accessible, see below)</td>
+            <td>content/subfolder.md</td>
+            <td><del>/subfolder</del> (not accessible, see below)</td>
         </tr>
         <tr>
-            <td>content/sub/index.md</td>
-            <td>?sub (same as above)</td>
+            <td>content/subfolder/index.md</td>
+            <td>/subfolder/ (overrides the file above)</td>
         </tr>
         <tr>
-            <td>content/sub/page.md</td>
-            <td>?sub/page</td>
+            <td>content/subfolder/page.md</td>
+            <td>/subfolder/page</td>
         </tr>
         <tr>
             <td>content/a/very/long/url.md</td>
-            <td>?a/very/long/url</td>
+            <td>/a/very/long/url</td>
         </tr>
     </tbody>
 </table>
 
+Now that you know how Pico generates urls, let's learn how to actually *create* that content!
 
+## YAML and Markdown
+
+[YAML][] and [Markdown][] are a common pair in today's world, possibly due to the popularity of GitHub.  YAML provides an easy to understand syntax for your pages' metadata while Markdown provides easy, plain-text formatting of your content.  The pair make a great combination, and once you learn them you'll find it hard to disagree.
+
+### YAML - Yay, A Metadata Lesson
+
+Writing your metadata in YAML is as easy as writing it out.  Each of your content files in Pico will begin with a "YAML Header".  It will look something like this:
+
+```
+---
+Title: Welcome
+Description: Welcome to my website, where we discuss the finer points of Pico.
+Author: Joe Bloggs
+Date: 2013/01/01
+Robots: noindex,nofollow
+Template: index
+---
+```
+
+Simple, huh?  And it gets better too.  These are all the variables that Pico supports by default, but none of them are *required* for your page to work.  The only "required" item on the list above is "Title", because Pico's Default Theme uses the page Title in order to link to it.
+
+Each of these metadata fields are utilized by your Pico theme. Some themes may add or require additional fields in order to function.  We'll go into that in more detail about these when we discuss [Theming and Customization][Theming].  For now, stick with Title, Description, Author, and Date, as these are things most pages should probably have.
+
+### Markdown - Because Why Mark *Up*?
+
+Markdown makes formatting your pages simple and intuitive.  According to its creator, John Gruber, "Markdown allows you to write using an easy-to-read, easy-to-write plain text format, then convert it to structurally valid XHTML (or HTML)."
+
+Sounds good, right?  When writing your Pico content files, you get to use the formatting power of [Markdown], [Markdown Extra][MarkdownExtra], and regular HTML.
+
+For simplicity, you'll want to stick with Markdown/Markdown Extra wherever you can, but on occasion you may want more control.  You can use regular HTML code within your document, but be aware that within HTML tags, Pico will not process Markdown.
+
+### Variable Variables
+
+When writing your content, there are also some variables you can use to make your life easier.  By inserting these into your markdown, you can use their values dynamically in your pages.
+
+* `%site_title%` - The title of your Pico site.
+* `%base_url%` - The URL of your Pico site.  Internal links can be specified using `%base_url%/sub/page` (`%base_url%?sub/page` without URL rewriting).
+* `%theme_url%` - The URL to the folder of your current theme.
+* `%meta.*%` - By using the `meta` variable, you can access any YAML variable of the current page, for example, `%meta.author%` would be replaced with `Joe Bloggs` in our YAML example above.
+
+## Let's Get Started
+
+Now that we know the basics of creating pages in Pico, we can start generating our own content.  Remember, every page starts with a YAML header beore the markdown starts.  If you're ever unsure of how this should look, you can check out some of the files in `content-sample`.
+
+### Somewhere to Land
+
+The first page you'll want to create is your "index" or "landing page".  This is the file that will be loaded when a user visits the `base_url` of your Pico site.  Start by creating a blank file named `index.md` in the `content` folder.  In the previous section, we discussed how to use YAML and Markdown to create your content.  Use what you've learned to create a landing page worth visiting!
+
+### 404 Heading Not Found
+
+If Pico cannot find a given file, it'll instead show `content/404.md`.  You can customize this file to create your own, personal 404 error.
+
+You can also add `404.md` to any subfolder and it'll become the 404 page for that folder.  For example, if you wanted to have a special 404 error page for your blog, you might create this file at `content/blog/404.md`.
+
+### Images, Downloads, and Other Assets
+
+So, you're typing away, creating some content, when you think, "I'd like to put an image here".  You link to an image within your content folder, only to discover that it the image generates a 404 error.
+
+If you're using our recommended [Apache][ApacheConfig] or [Nginx][NginxConfig], this is because we deny access to the content folder by default for security reasons.  You probably don't want somebody else probing around in your site's content folder either.
+
+Instead, all images, downloads, and other website assets should be placed in the `assets` folder.  You'll find this location in the root of your Pico install.  How you choose to organize this folder is up to you though.
+
+It may seem counter-intuitive at first, but ultimately, we feel it's tidier this way.  It stops your content folder from being overrun with files that don't belong there.
+
+It's easy to link to an item in your assets folder, just use `%base_url%/assets/` in your Markdown.  For example `![Image Title](%base_url%/assets/image.png)`.
+
+### To Blog or Not to Blog
+
+Pico is not blogging software.  That being said, It is fairly easy to create a blog using Pico, as long as you're aware of it's limitations.  Pico lacks many standard blogging features, such as authentication, tagging, pagination, and social features.  There are third party plugins available to help bridge this gap though.
+
+In the not-too-distant future, `Pico 2.0` will ship with optional, but officially supported blogging plugins and tools.  We've even got an official editor in the works, so stay tuned.
+
+In the meantime, see what you can do with the current version.  You'll find that Pico is incredibly extendable.
+
+Check out our [Cookbook][] for some tips and code snippets that will help you use Pico for [blogging][CookbookBlogging].
+
+[InlineReadme]: {{ site.gh_project_url }}/blob/master/content-sample/index.md
+[YAML]: https://en.wikipedia.org/wiki/YAML
+[Markdown]: http://daringfireball.net/projects/markdown/syntax
+[MarkdownExtra]: https://michelf.ca/projects/php-markdown/extra/
+[Cookbook]: {{ site.github.url }}/cookbook/
+[CookbookBlogging]: {{ site.github.url }}/cookbook/#BloggingWithPico
+[Theming]: {{ site.github.url }/docs/theming
+
+{% comment %}
+
+* Move existing [blogging section](http://picocms.org/docs/#blogging) to cookbook.
+
+---
 
 ### Blogging
 
@@ -174,7 +200,4 @@ If you want to use Pico as a blogging software, you probably want to do somethin
         Make sure to exclude blog articles from your page navigation. You can achieve this by adding <code>{&#37; if not (page.id starts with "blog/") &#37;}...{&#37; endif &#37;}</code> to the navigation loop (<code>{&#37; for page in pages &#37;}...{&#37; endfor &#37;}</code>) in your theme's <code>index.twig</code>.
     </li>
 </ol>
-
-[Markdown]: http://daringfireball.net/projects/markdown/syntax
-[MarkdownExtra]: https://michelf.ca/projects/php-markdown/extra/
-[YAML]: https://en.wikipedia.org/wiki/YAML
+{% endcomment %}

--- a/docs/creating-content.md
+++ b/docs/creating-content.md
@@ -1,0 +1,180 @@
+---
+layout: docs
+title: Creating Content
+headline: Creating Content in Pico
+description: |
+  Markdown and YAML make creating content in Pico a breeze.<br />
+  This guide will teach you the basics of these formatting syntaxes<br />
+  and how they relate to Pico.
+toc:
+  downloading-and-installing-pico:
+    _title: Downloading and Installing Pico
+    developer-instructions: Developer Instructions
+  url-rewriting:
+    _title: URL Rewriting
+    apache: Apache
+    nginx: Nginx
+  configuring-pico: Configuring Pico
+nav-url: /docs/
+
+---
+
+## Simple but Elegant Content Management
+
+Pico's flat file nature is a simple approach to content management.  Pico has no dashboard or admin panel.  There's no clunky interface for creating posts or pages.
+
+In all their efforts to be all-in-one solutions, many CMS's provide an overwhelming amount of options, metadata, interfaces within interfaces, and other overhead to worry about.
+
+Pico is simple: You just create a file and write.
+
+### The Content Folder
+
+When you first set up Pico, you'll notice you have a `content-sample` folder in your Pico root directory.  This folder provides a set of basic sample pages for testing Pico.  It also includes [Pico's inline Readme][InlineReadme], a simple, quick-start reference to using Pico.  When you're ready to create your own content, create a `content` folder in Pico's root directory.  There's no need to remove the `content-sample` folder, or to reconfigure Pico.  Pico will automatically switch to using the `content` folder if it exists.
+
+### All about URLs
+
+## YAML and Markdown
+
+[YAML][] and [Markdown][] are a common pair in today's world.  YAML provides an easy to understand syntax for your pages' metadata while Markdown provides easy, plain-text formatting of your content.  The pair make a great combination, and once you learn them you'll find it hard to disagree.
+
+* possibly due to the popularity of Jekyll... need a better reason than that.
+
+### YAML - Yay, A Metadata Lesson
+
+Writing your metadata in YAML is as easy as writing it out.  Each of your content files in Pico will begin with a "YAML Header".  It will look something like this:
+
+```
+---
+Title: Welcome
+Description: This description will go in the meta description tag
+Author: Joe Bloggs
+Date: 2013/01/01
+Robots: noindex,nofollow
+Template: index
+---
+```
+
+* Date format?  Update Example?
+
+Simple, huh?  And it gets better too.  These are all the variables that Pico supports by default, but none of them are *required* for your page to work.  The only "required" item on the list above is "Title", but only because Pico's Default Theme uses the page Title in order to link to it.
+
+Each of these metadata fields are utilized by your Pico theme, and some themes may add or require additional fields in order to function.
+
+* Needs more depth.  Reference About page and expand on examples.  Link to cookbook?
+
+### Markdown - Because Why Mark *Up*?
+
+```
+### Text File Markup
+
+Text files are marked up using [Markdown][] and [Markdown Extra][MarkdownExtra]. They can also contain regular HTML.
+
+At the top of text files you can place a block comment and specify certain meta attributes of the page using [YAML][] (the "YAML header"). For example:
+
+
+These values will be contained in the `{% raw %}{{ meta }}{% endraw %}` variable in themes (see below).
+
+There are also certain variables that you can use in your text files:
+
+* `%site_title%` - The title of your Pico site
+* `%base_url%` - The URL to your Pico site; internal links can be specified using `%base_url%?sub/page`
+* `%theme_url%` - The URL to the currently used theme
+* `%meta.*%` - Access any meta variable of the current page, e.g. `%meta.author%` is replaced with `Joe Bloggs`
+```
+
+## Let's Get Started
+
+### Somewhere to Land
+
+The first page you'll want to create is your "index" or "landing page".  This is the file that will be loaded when a user visits the `base_url` of your Pico site.  Start by creating a blank file named `index.md` in the `content` folder.  In the previous section, we discussed how to use YAML and Markdown to create your content.  Use what you've learned to create a landing page worth visiting!
+
+### 404 Heading Not found
+
+```
+If a file cannot be found, the file `content/404.md` will be shown. You can add `404.md` files to any directory. So, for example, if you wanted to use a special error page for your blog, you could simply create `content/blog/404.md`.
+
+```
+
+### Images, Downloads, and Other Assets
+
+```
+As a common practice, we recommend you to separate your contents and assets (like images, downloads, etc.). We even deny access to your `content` directory by default. If you want to use some assets (e.g. a image) in one of your content files, you should create an `assets` folder in Pico's root directory and upload your assets there. You can then access them in your markdown using `%base_url%/assets/` for example: `![Image Title](%base_url%/assets/image.png)`
+```
+
+* provide empty assets folder?
+
+### To Blog or Not to Blog
+
+[InlineReadme]: needs-url
+---
+
+## Creating Content (All about URL's)
+
+If you create a folder within the content folder (e.g. `content/sub`) and put an `index.md` inside it, you can access that folder at the URL `http://example.com/?sub`. If you want another page within the sub folder, simply create a text file with the corresponding name and you will be able to access it (e.g. `content/sub/page.md` is accessible from the URL `http://example.com/?sub/page`). Below we've shown some examples of locations and their corresponding URLs:
+
+<table style="width: 100%; max-width: 40em;">
+    <thead>
+        <tr>
+            <th style="width: 50%;">Physical Location</th>
+            <th style="width: 50%;">URL</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>content/index.md</td>
+            <td>/</td>
+        </tr>
+        <tr>
+            <td>content/sub.md</td>
+            <td><del>?sub</del> (not accessible, see below)</td>
+        </tr>
+        <tr>
+            <td>content/sub/index.md</td>
+            <td>?sub (same as above)</td>
+        </tr>
+        <tr>
+            <td>content/sub/page.md</td>
+            <td>?sub/page</td>
+        </tr>
+        <tr>
+            <td>content/a/very/long/url.md</td>
+            <td>?a/very/long/url</td>
+        </tr>
+    </tbody>
+</table>
+
+
+
+### Blogging
+
+Pico is not blogging software - but makes it very easy for you to use it as a blog. You can find many plugins out there implementing typical blogging features like authentication, tagging, pagination and social plugins. See the below Plugins section for details.
+
+If you want to use Pico as a blogging software, you probably want to do something like the following:
+<ol>
+    <li>
+        Put all your blog articles in a separate <code>blog</code> folder in your <code>content</code> directory. All these articles should have both a <code>Date</code> and <code>Template</code> meta header, the latter with e.g. <code>blog-post</code> as value (see Step 2).
+    </li>
+    <li>
+        Create a new Twig template called <code>blog-post.twig</code> (this must match the <code>Template</code> meta header from Step 1) in your theme directory. This template probably isn't very different from your default <code>index.twig</code>, it specifies ow your article pages will look like.
+    </li>
+    <li>
+        Create a <code>blog.md</code> in your <code>content</code> folder and set its <code>Template</code> meta header to e.g. <code>blog</code>. Also create a <code>blog.twig</code> in your theme directory. This template will show a list of your articles, so you probably want to do something like this:
+
+        {% raw %}<pre><code>{% for page in pages|sort_by("time")|reverse %}
+    {% if page.id starts with &quot;blog/&quot; %}
+        &lt;div class=&quot;post&quot;&gt;
+            &lt;h3&gt;&lt;a href=&quot;{{ page.url }}&quot;&gt;{{ page.title }}&lt;/a&gt;&lt;/h3&gt;
+            &lt;p class=&quot;date&quot;&gt;{{ page.date_formatted }}&lt;/p&gt;
+            &lt;p class=&quot;excerpt&quot;&gt;{{ page.description }}&lt;/p&gt;
+        &lt;/div&gt;
+    {% endif %}
+{% endfor %}</code></pre>{% endraw %}
+    </li>
+    <li>
+        Make sure to exclude blog articles from your page navigation. You can achieve this by adding <code>{&#37; if not (page.id starts with "blog/") &#37;}...{&#37; endif &#37;}</code> to the navigation loop (<code>{&#37; for page in pages &#37;}...{&#37; endfor &#37;}</code>) in your theme's <code>index.twig</code>.
+    </li>
+</ol>
+
+[Markdown]: http://daringfireball.net/projects/markdown/syntax
+[MarkdownExtra]: https://michelf.ca/projects/php-markdown/extra/
+[YAML]: https://en.wikipedia.org/wiki/YAML

--- a/docs/creating-content.md
+++ b/docs/creating-content.md
@@ -102,7 +102,7 @@ Template: index
 
 Simple, huh?  And it gets better too.  These are all the variables that Pico supports by default, but none of them are *required* for your page to work.  The only "required" item on the list above is "Title", because Pico's Default Theme uses the page Title in order to link to it.
 
-Each of these metadata fields are utilized by your Pico theme. Some themes may add or require additional fields in order to function.  We'll go into that in more detail about these when we discuss [Theming and Customization][Theming].  For now, stick with Title, Description, Author, and Date, as these are things most pages should probably have.
+Each of these metadata fields are utilized by your Pico theme. Some themes may add or require additional fields in order to function.  We'll go into that in more detail about these when we discuss [Theming with Twig][Theming].  For now, stick with Title, Description, Author, and Date, as these are things most pages should probably have.
 
 ### Markdown - Because Why Mark *Up*?
 
@@ -157,13 +157,23 @@ In the meantime, see what you can do with the current version.  You'll find that
 
 Check out our [Cookbook][] for some tips and code snippets that will help you use Pico for [blogging][CookbookBlogging].
 
+---
+
+## Up Next...
+
+You've installed Pico and now you've created a simple page or two.  What now?  Well, Pico's default theme is a little sparse.  It's not really meant to be used in production.  The default theme is more of a platform for you to customize to meet your own needs.
+
+How do you do this though?  That's what our next guide will cover.  You'll learn how to customize Pico using the powerful template engine, Twig.  Click through to proceed to the next article.  We'll see you there.
+
+<p class="aligncenter" markdown="1"><a href="{{ site.github.url }}/docs/theming-with-twig" class="button">Theming with Twig</a></p>
+
 [InlineReadme]: {{ site.gh_project_url }}/blob/master/content-sample/index.md
 [YAML]: https://en.wikipedia.org/wiki/YAML
 [Markdown]: http://daringfireball.net/projects/markdown/syntax
 [MarkdownExtra]: https://michelf.ca/projects/php-markdown/extra/
 [Cookbook]: {{ site.github.url }}/cookbook/
 [CookbookBlogging]: {{ site.github.url }}/cookbook/#BloggingWithPico
-[Theming]: {{ site.github.url }}/docs/theming
+[Theming]: {{ site.github.url }}/docs/theming-with-twig
 
 {% comment %}
 

--- a/docs/creating-content.md
+++ b/docs/creating-content.md
@@ -13,14 +13,14 @@ toc:
     all-about-urls: All About URLs
   yaml-and-markdown:
     _title: YAML and Markdown
-    yaml---yay--a-metadata-lesson: YAML - Yay, A Metadata Lesson
-    markdown---Because-why-mark--up--: Markdown - Because Why Mark *Up*?
+    yaml---yay-a-metadata-lesson: YAML - Yay, A Metadata Lesson
+    markdown---because-why-mark-up: Markdown - Because Why Mark *Up*?
     variable-variables: Variable Variables
-  let-s-get-started:
+  lets-get-started:
     _title: Let's Get Started
     somewhere-to-land: Somewhere to Land
     404-heading-not-found: 404 Heading Not Found
-    images--downloads--and-other-assets: Images, Downloads, and Other Assets
+    images-downloads-and-other-assets: Images, Downloads, and Other Assets
     to-blog-or-not-to-blog: To Blog or Not to Blog
 nav-url: /docs/
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -141,7 +141,7 @@ Other interesting options you may want to configure include theme, date format, 
 
 So, we've shown you everything you need to setup Pico on your server.  Now it's time for the fun stuff.  In the next guide, you'll learn how to create some content.  Click through to proceed to the next article.
 
-<p class="aligncenter" markdown="1"><a href="{{ site.github.url }}/in-depth/creating-content" class="button">Creating Content</a></p>
+<p class="aligncenter" markdown="1"><a href="{{ site.github.url }}/docs/creating-content" class="button">Creating Content</a></p>
 
 
 [Upgrading]: {{ site.github.url }}/in-depth/upgrade/
@@ -158,7 +158,7 @@ So, we've shown you everything you need to setup Pico on your server.  Now it's 
 
 * Need to figure out how to make this button work using Markdown...
 
-[NextGuide]: {{ site.github.url }}/in-depth/creating-content
+[NextGuide]: {{ site.github.url }}/docs/creating-content
 <p class="aligncenter" markdown="1"> [Creating Content][NextGuide]{.button} </p>
 
 ---

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -48,7 +48,9 @@ If you are upgrading your Pico installation, please read our [Upgrading][] guide
 
 The best way to get yourself a copy of Pico is to download the [Latest Release][] from our GitHub Page.  This pre-bundled release comes with all the dependencies necessary for Pico to run.  The only system requirement of your webserver is that it's running **at least PHP 5.3 or newer**.
 
-Once you have the latest release, simply upload all the extracted files to the `httpdocs` directory (e.g. `/var/www/html`) of your server.  If you are using Apache, make sure you upload our included `.htaccess` file for a worry-free configuration.  **Please Note**: Depending on your OS (specifically Mac and Linux), after you've extracted the files, `.htaccess` may appear hidden by your file manager.
+Once you have the latest release, simply upload all the extracted files to the `httpdocs` directory (e.g. `/var/www/html`) of your server.  If you are using Apache, make sure you upload our included `.htaccess` file for a worry-free configuration.  **Please Note**: Depending on your OS (specifically Linux and macOS), after you've extracted the files, `.htaccess` may appear hidden by your file manager.
+
+* Include download button?
 
 ### Developer Instructions
 
@@ -148,7 +150,7 @@ So, we've shown you everything you need to setup Pico on your server.  Now it's 
 [Packagist.org]: http://packagist.org/packages/picocms/pico
 [ModRewrite]: https://httpd.apache.org/docs/current/mod/mod_rewrite.html
 [NginxConfig]: {{ site.github.url }}/in-depth/nginx/
-[NginxPHP]: {{ site.github.url }}/in-depth/nginx/#php-configuration
+[NginxPHP]: {{ site.github.url }}/docs/nginx/#php-configuration
 [GettingHelp]: {{ site.github.url }}/docs/#getting-help
 [ConfigTemplate]: {{ site.gh_project_url }}/blob/{{ site.gh_project_branch }}/config/config.php.template
 

--- a/installing.md
+++ b/installing.md
@@ -92,24 +92,25 @@ Additionally, you'll need to either add `fastcgi_param PICO_URL_REWRITING 1;` to
 
 ## Configuring Pico
 
-Pico is ready to go, right out of the box.  However, unless you want your website to be called "Pico", there are a few configuration options you'll probably want to set.
+Pico is ready to go, right out of the box.  However, unless you want your website to be called "Pico", there's at least one configuration option you'll want to set.
 
-{% comment %}
+To configure Pico, start by navigating to the `config` directory and copying/moving Pico's included `config.php.template` to `config.php`.
 
-You can override the default Pico settings (and add your own custom settings) by editing `config/config.php` in the Pico directory. For a brief overview of the available settings and their defaults see [`config/config.php.template`][ConfigTemplate]. To override a setting, copy `config/config.php.template` to `config/config.php`, uncomment the setting and set your custom value.
+Next, in your new `config.php`, you can specify the name of your website by changing the line `// $config['site_title'] = 'Pico';`.  You'll also want to *uncomment* this line by removing the `//` at the beginning.
 
-[ConfigTemplate]: {{ site.gh_project_url }}/blob/{{ site.gh_project_branch }}/config/config.php.template
+That's it!  That's the only configuration that's needed.  You'll find `config.php` is pretty well [documented inline][ConfigTemplate], so we won't go into detail about the rest of the options here.
 
-{% endcomment %}
+Other interesting options you may want to configure include theme, date format, and page order.  A custom theme or plugin may have it's own options for you to add to `config.php`, so we've labeled a section at the bottom where you can add them.
 
 [Upgrading]: {{ site.github.url }}/in-depth/upgrade/
-[LatestRelease]: {{ site.gh_project_url }}/releases/latest
+[Latest Release]: {{ site.gh_project_url }}/releases/latest
 [Composer]: https://getcomposer.org/
 [Packagist.org]: http://packagist.org/packages/picocms/pico
 [ModRewrite]: https://httpd.apache.org/docs/current/mod/mod_rewrite.html
 [NginxConfig]: {{ site.github.url }}/in-depth/nginx/
 [NginxPHP]: {{ site.github.url }}/in-depth/nginx/#php-configuration
 [GettingHelp]: {{ site.github.url }}/docs/#getting-help
+[ConfigTemplate]: {{ site.gh_project_url }}/blob/{{ site.gh_project_branch }}/config/config.php.template
 
 {% comment %}
 
@@ -146,12 +147,8 @@ Access Pico from http://localhost:8080.
 
 [PHPServer]: http://php.net/manual/en/features.commandline.webserver.php
 
-
-
-
-
-
-
+---
+---
 
 Here's some quotes from that thread:
 

--- a/installing.md
+++ b/installing.md
@@ -133,6 +133,15 @@ That's it!  That's the only configuration that's needed.  You'll find `config.ph
 
 Other interesting options you may want to configure include theme, date format, and page order.  A custom theme or plugin may have it's own options for you to add to `config.php`, so we've labeled a section at the bottom where you can add them.
 
+---
+
+## Up Next...
+
+So, we've shown you everything you need to setup Pico on your server.  Now it's time for the fun stuff.  In the next guide, you'll learn how to create some content.  Click through to proceed to the next article.
+
+<p class="aligncenter" markdown="1"><a href="{{ site.github.url }}/in-depth/creating-content" class="button">Creating Content</a></p>
+
+
 [Upgrading]: {{ site.github.url }}/in-depth/upgrade/
 [Latest Release]: {{ site.gh_project_url }}/releases/latest
 [Composer]: https://getcomposer.org/
@@ -143,11 +152,14 @@ Other interesting options you may want to configure include theme, date format, 
 [GettingHelp]: {{ site.github.url }}/docs/#getting-help
 [ConfigTemplate]: {{ site.gh_project_url }}/blob/{{ site.gh_project_branch }}/config/config.php.template
 
-## Creating Content
-
-* Up next, next article, whatever...
-
 {% comment %}
+
+* Need to figure out how to make this button work using Markdown...
+
+[NextGuide]: {{ site.github.url }}/in-depth/creating-content
+<p class="aligncenter" markdown="1"> [Creating Content][NextGuide]{.button} </p>
+
+---
 
 ## Testing Pico
 

--- a/installing.md
+++ b/installing.md
@@ -1,0 +1,185 @@
+---
+layout: docs
+title: Installing and Configuring Pico
+headline: Installing and Configuring Pico
+description: |
+  Installing Pico couldn't be easier.<br />
+  This guide will cover everything you need to know to get Pico up and running.
+toc:
+  downloading-and-installing-pico:
+    _title: Downloading and Installing Pico
+    developer-instructions: Developer Instructions
+  url-rewriting:
+    _title: URL Rewriting
+    apache: Apache
+    nginx: Nginx
+  configuring-pico: Configuring Pico
+nav-url: /docs/
+---
+
+Installing Pico is as simple as uploading Pico's directory to your webserver.  Seriously.  But while we could leave it at that, this guide will dive deeper into the subject to cover all you'd ever need to know about the process.
+
+If you are upgrading your Pico installation, please read our [Upgrading][] guide instead.
+
+## Downloading and Installing Pico
+
+The best way to get yourself a copy of Pico is to download the [Latest Release][] from our GitHub Page.  This pre-bundled release comes with all the dependencies necessary for Pico to run.  The only system requirement of your webserver is that it's running **at least PHP 5.3 or newer**.
+
+Once you have the latest release, simply upload all the extracted files to the `httpdocs` directory (e.g. `/var/www/html`) of your server.  If you are using Apache, make sure you upload our included `.htaccess` file for a worry-free configuration.  **Please Note**: Depending on your OS (specifically Mac and Linux), after you've extracted the files, `.htaccess` may appear hidden by your file manager.
+
+### Developer Instructions
+
+Optionally, you could chose to install Pico using Git and Composer.  This method is more difficult, and targeted mainly at advanced users and developers.
+
+Open a shell on your server and navigate to the location you'd like to install Pico.  From there, use Git to clone Pico's Git repository to your server:
+
+```
+$ git clone {{ site.gh_project_url }}.git
+```
+
+Note that this will give you a copy of Pico's `master` branch, which could be *unstable*.  In general, we would *not* consider this to be ready for production use.  Bugs may exist and breaks could occur, so use at your own risk.
+
+Next, download [Composer][] and run it with the `install` option:
+
+```
+$ curl -sS https://getcomposer.org/installer | php
+$ php composer.phar install
+```
+
+This will download and install all of the dependencies required to run Pico.
+
+Pico is also available on [Packagist.org][] and may be included in other projects via `composer require picocms/pico`.
+
+## URL Rewriting
+
+Pico's default URL's are already pretty user friendly out of the box.  By default, they look like this: `http://example.com/pico/?sub/page`.  You'll note the `?` after the Pico directory.  This `?` in the URL is not ideal, and honestly a little "unsightly", especially on a production website.
+
+This is where Pico's optional URL Rewriting comes in.  It takes the `?` out of the URL, turning `http://example.com/pico/?sub/page` into `http://example.com/pico/sub/page`.
+
+To take advantage of this feature, you'll need a webserver that supports rewriting.  Nginx typically comes configured with a built-in `http_rewrite` module, while Apache requires `mod_rewrite` to be enabled.  If you are running Pico on a shared webhosting account, then support for these features depends on the way your individual hosting provider has configured their server.
+
+Provided your server has rewrite functionality available, both Apache and Nginx can be configured to use it to rewrite Pico's URL's.
+
+### Apache
+
+If you're using Apache, you're in luck: Our included `.htaccess` file should take care of all the necessary configuration automatically.  If you receive an error message from your webserver, please make sure that the [`mod_rewrite` module][ModRewrite] is enabled.
+
+If you find that, for whatever reason, rewritten URL's work properly but Pico is still inserting a `?` into your URL's, you can force Pico to use rewritten ones by setting `$config['rewrite_url'] = true;` in your [Pico Config](#configuring-pico) (`config/config.php`).
+
+### Nginx [Learn more…][NginxConfig]{:.learn-more}
+{:#nginx}
+
+If you're using Nginx, configuration is a little more involved.  We have an entire [Nginx Guide][NginxConfig] to help walk you through the process.
+
+The following configuration excerpt is somewhat of a "tl;dr" version of a very extensive topic.  It should provide the *bare minimum* configuration you need for Pico.  If you have any trouble, please read all of the aforementioned [Nginx Guide][NginxConfig].  For additional assistance, please refer to our ["Getting Help"][GettingHelp] page.
+
+* Hmm, [GettingHelp][] is going to be refereed to a LOT... maybe I should write that ahead of time.
+
+```
+location ~ /pico/(\.htaccess|\.git|config|content|content-sample|lib|vendor|CHANGELOG\.md|composer\.(json|lock)) {
+	return 404;
+}
+
+location ~ ^/pico(.*) {
+	index index.php;
+	try_files $uri $uri/ /pico/index.php?$1&$args;
+}
+```
+
+Lines `1` to `3` of this example are for denying access to Pico's internal files.  This is recommend for security reasons, and is included in `.htaccess` for our Apache users.  Lines `5` to `8` provide the URL rewriting scheme.  You'll need to adjust the path of `/pico` on lines `1`, `5`, and `7` to match your own Pico installation directory.
+
+Additionally, you'll need to either add `fastcgi_param PICO_URL_REWRITING 1;` to your [PHP location block][NginxPHP] or specify `$config['rewrite_url'] = true;` in your [Pico Config](#configuring-pico) (`config/config.php`).
+
+## Configuring Pico
+
+Pico is ready to go, right out of the box.  However, unless you want your website to be called "Pico", there are a few configuration options you'll probably want to set.
+
+{% comment %}
+
+You can override the default Pico settings (and add your own custom settings) by editing `config/config.php` in the Pico directory. For a brief overview of the available settings and their defaults see [`config/config.php.template`][ConfigTemplate]. To override a setting, copy `config/config.php.template` to `config/config.php`, uncomment the setting and set your custom value.
+
+[ConfigTemplate]: {{ site.gh_project_url }}/blob/{{ site.gh_project_branch }}/config/config.php.template
+
+{% endcomment %}
+
+[Upgrading]: {{ site.github.url }}/in-depth/upgrade/
+[LatestRelease]: {{ site.gh_project_url }}/releases/latest
+[Composer]: https://getcomposer.org/
+[Packagist.org]: http://packagist.org/packages/picocms/pico
+[ModRewrite]: https://httpd.apache.org/docs/current/mod/mod_rewrite.html
+[NginxConfig]: {{ site.github.url }}/in-depth/nginx/
+[NginxPHP]: {{ site.github.url }}/in-depth/nginx/#php-configuration
+[GettingHelp]: {{ site.github.url }}/docs/#getting-help
+
+{% comment %}
+
+## Testing Pico
+
+* Is there really a use case for this?  Who has PHP installed but no webserver?  Maybe a PHP developer on their local box... but they'd probably already know about php's built-in server.  I don't see a point to including non-"production ready" instructions in this document.
+
+
+## Run
+
+You have nothing to consider specially, simply navigate to your Pico install using your favorite web browser. Pico's default contents will explain how to use your brand new, stupidly simple, blazing fast, flat file CMS.
+
+### You don't have a web server?
+Starting with PHP 5.4 the easiest way to *try* Pico is using PHP's own [built-in web server][PHPServer]. **Please Note** that PHP's built-in web server is for development and testing purposes only!  It is **not** suitable for production use.
+
+* If you decide you like Pico, but need help setting up a more permanent solution, please see our [some section below about server configuration]().
+* Also, only mentioning PHP's internal server seems a bit like a wasted page.  Do we even need a "Run" section?
+
+
+* If they don't have a web server, perhaps we should recommend one or link to a guide for setting up their own.
+* I feel like not using PHP's internal web server should be more emphasized... or maybe not even recommended in the first place...
+* Wait... if they don't have a web server... why do they have PHP?  Why not just recommend downloading Apache or something?*
+  * To be honest, I have no idea what installing Apache on Windows would look like.  I guess you'd probably need to download PHP separately or something.  Sometimes I forget how backwards they do things. ;P
+
+#### Step 1
+Navigate to Pico's installation directory using a shell.
+
+#### Step 2
+Start PHPs built-in web server:
+<pre><code>$ php -S 127.0.0.1:8080</code></pre>
+
+#### Step 3
+Access Pico from http://localhost:8080.
+
+[PHPServer]: http://php.net/manual/en/features.commandline.webserver.php
+
+
+
+
+
+
+
+
+Here's some quotes from that thread:
+
+    Page Topics
+
+        An "Installing Pico" page that covers, in-depth, the concepts of installing and configuring Pico, your webserver (well, links to external resources anyway) and etc. Everything up until you're looking at Pico's sample content.
+        A "Creating Content" page that goes over YAML and Markdown.
+        Perhaps a general, "Usage" type page that covers things like how URLs work, how to lay out and organize your website, separating content and assets, more about config options, etc.
+        Customization: An in-depth guide to installing community themes, creating your own, understanding Twig, Pico variables, everything. Not plugins though.
+        A separate page for Plugins (and plugin development).
+        Maybe a combination of "Getting Help" and "Contributing" (or "Getting Involved"). It should be a generally community-focused page. On that note, I think it would be great if we eventually had a place for non-development, non-bug related community discussions. I don't want to say a "forum" because that feels like a really outdated notion, but a "place" to develop a community nonetheless.
+
+    Table of Contents
+
+    When on the Overview Page:
+
+    * Installing Pico
+    * Creating Content
+    * Customization
+    * Getting Help
+
+    When on Creating Content Page:
+
+    * Installing Pico
+    * Creating Content
+       * YAML
+       * Markdown
+       * Etc
+    * Customization
+    * Getting Help
+{% endcomment %}

--- a/installing.md
+++ b/installing.md
@@ -73,8 +73,6 @@ If you're using Nginx, configuration is a little more involved.  We have an enti
 
 The following configuration excerpt is somewhat of a "tl;dr" version of a very extensive topic.  It should provide the *bare minimum* configuration you need for Pico.  If you have any trouble, please read all of the aforementioned [Nginx Guide][NginxConfig].  For additional assistance, please refer to our ["Getting Help"][GettingHelp] page.
 
-* Hmm, [GettingHelp][] is going to be refereed to a LOT... maybe I should write that ahead of time.
-
 ```
 location ~ /pico/(\.htaccess|\.git|config|content|content-sample|lib|vendor|CHANGELOG\.md|composer\.(json|lock)) {
 	return 404;
@@ -86,7 +84,11 @@ location ~ ^/pico(.*) {
 }
 ```
 
-Lines `1` to `3` of this example are for denying access to Pico's internal files.  This is recommend for security reasons, and is included in `.htaccess` for our Apache users.  Lines `5` to `8` provide the URL rewriting scheme.  You'll need to adjust the path of `/pico` on lines `1`, `5`, and `7` to match your own Pico installation directory.
+Lines `1` to `3` of this example are for denying access to Pico's internal files.  This is recommend for security reasons, and is included in `.htaccess` for our Apache users.
+
+Lines `5` to `8` provide the URL rewriting scheme.
+
+You'll need to adjust the path of `/pico` on lines `1`, `5`, and `7` to match your own Pico installation directory.
 
 Additionally, you'll need to either add `fastcgi_param PICO_URL_REWRITING 1;` to your [PHP location block][NginxPHP] or specify `$config['rewrite_url'] = true;` in your [Pico Config](#configuring-pico) (`config/config.php`).
 
@@ -96,9 +98,13 @@ Pico is ready to go, right out of the box.  However, unless you want your websit
 
 To configure Pico, start by navigating to the `config` directory and copying/moving Pico's included `config.php.template` to `config.php`.
 
-Next, in your new `config.php`, you can specify the name of your website by changing the line `// $config['site_title'] = 'Pico';`.  You'll also want to *uncomment* this line by removing the `//` at the beginning.
+Next, in your new `config.php`, you can specify the name of your website by changing the line:
 
-That's it!  That's the only configuration that's needed.  You'll find `config.php` is pretty well [documented inline][ConfigTemplate], so we won't go into detail about the rest of the options here.
+`// $config['site_title'] = 'Pico';`
+
+You'll also want to *uncomment* this line by removing the `//` at the beginning.
+
+That's it!  That's the only configuration that's needed.  You'll find `config.php` is pretty well documented [inline][ConfigTemplate], so we won't go into detail about the rest of the options here.
 
 Other interesting options you may want to configure include theme, date format, and page order.  A custom theme or plugin may have it's own options for you to add to `config.php`, so we've labeled a section at the bottom where you can add them.
 
@@ -111,6 +117,10 @@ Other interesting options you may want to configure include theme, date format, 
 [NginxPHP]: {{ site.github.url }}/in-depth/nginx/#php-configuration
 [GettingHelp]: {{ site.github.url }}/docs/#getting-help
 [ConfigTemplate]: {{ site.gh_project_url }}/blob/{{ site.gh_project_branch }}/config/config.php.template
+
+## Creating Content
+
+* Up next, next article, whatever...
 
 {% comment %}
 
@@ -179,4 +189,7 @@ Here's some quotes from that thread:
        * Etc
     * Customization
     * Getting Help
+
+* Hmm, [GettingHelp][] is going to be refereed to a LOT... maybe I should write that ahead of time.
+
 {% endcomment %}

--- a/installing.md
+++ b/installing.md
@@ -26,7 +26,7 @@ galleries:
           This is what Pico's folder looks like after installation.
         thumbnail: /style/images/docs/about/thumbnails/pico_folder.png
         fullsize: /style/images/docs/about/fullsize/pico_folder.png
-        styles: "float: right; margin-left: 2em; border: 1px solid #CCC; border-top: none;"
+        styles: "float: right; margin-left: 2em;"
   standalone_2:
     style: magnify
     images:
@@ -35,6 +35,7 @@ galleries:
         description: Configuring Pico is as simple as uncommenting a few lines in the included config template.
         thumbnail: /style/images/docs/about/thumbnails/config.png
         fullsize: /style/images/docs/about/fullsize/config.png
+        styles: "float: right; margin-left: 2em;"
 ---
 
 Installing Pico is as simple as uploading Pico's directory to your webserver.  Seriously.  But while we could leave it at that, this guide will dive deeper into the subject to cover all you'd ever need to know about the process.
@@ -43,9 +44,9 @@ If you are upgrading your Pico installation, please read our [Upgrading][] guide
 
 ## Downloading and Installing Pico
 
-The best way to get yourself a copy of Pico is to download the [Latest Release][] from our GitHub Page.  This pre-bundled release comes with all the dependencies necessary for Pico to run.  The only system requirement of your webserver is that it's running **at least PHP 5.3 or newer**.
-
 {% include gallery.html gallery='standalone_1' %}
+
+The best way to get yourself a copy of Pico is to download the [Latest Release][] from our GitHub Page.  This pre-bundled release comes with all the dependencies necessary for Pico to run.  The only system requirement of your webserver is that it's running **at least PHP 5.3 or newer**.
 
 Once you have the latest release, simply upload all the extracted files to the `httpdocs` directory (e.g. `/var/www/html`) of your server.  If you are using Apache, make sure you upload our included `.htaccess` file for a worry-free configuration.  **Please Note**: Depending on your OS (specifically Mac and Linux), after you've extracted the files, `.htaccess` may appear hidden by your file manager.
 
@@ -116,9 +117,9 @@ Additionally, you'll need to either add `fastcgi_param PICO_URL_REWRITING 1;` to
 
 ## Configuring Pico
 
-Pico is ready to go, right out of the box.  However, unless you want your website to be called "Pico", there's at least one configuration option you'll want to set.
-
 {% include gallery.html gallery='standalone_2' %}
+
+Pico is ready to go, right out of the box.  However, unless you want your website to be called "Pico", there's at least one configuration option you'll want to set.
 
 To configure Pico, start by navigating to the `config` directory and copying/moving Pico's included `config.php.template` to `config.php`.
 

--- a/installing.md
+++ b/installing.md
@@ -15,6 +15,26 @@ toc:
     nginx: Nginx
   configuring-pico: Configuring Pico
 nav-url: /docs/
+galleries:
+  standalone_1:
+    style: magnify
+    images:
+      -
+        heading: Installation is Easy!
+        description: |
+          Simply upload Pico's files to your server and you're done!<br>
+          This is what Pico's folder looks like after installation.
+        thumbnail: /style/images/docs/about/thumbnails/pico_folder.png
+        fullsize: /style/images/docs/about/fullsize/pico_folder.png
+        styles: "float: right; margin-left: 2em; border: 1px solid #CCC; border-top: none;"
+  standalone_2:
+    style: magnify
+    images:
+      -
+        heading: Configuration is Easy Too!
+        description: Configuring Pico is as simple as uncommenting a few lines in the included config template.
+        thumbnail: /style/images/docs/about/thumbnails/config.png
+        fullsize: /style/images/docs/about/fullsize/config.png
 ---
 
 Installing Pico is as simple as uploading Pico's directory to your webserver.  Seriously.  But while we could leave it at that, this guide will dive deeper into the subject to cover all you'd ever need to know about the process.
@@ -24,6 +44,8 @@ If you are upgrading your Pico installation, please read our [Upgrading][] guide
 ## Downloading and Installing Pico
 
 The best way to get yourself a copy of Pico is to download the [Latest Release][] from our GitHub Page.  This pre-bundled release comes with all the dependencies necessary for Pico to run.  The only system requirement of your webserver is that it's running **at least PHP 5.3 or newer**.
+
+{% include gallery.html gallery='standalone_1' %}
 
 Once you have the latest release, simply upload all the extracted files to the `httpdocs` directory (e.g. `/var/www/html`) of your server.  If you are using Apache, make sure you upload our included `.htaccess` file for a worry-free configuration.  **Please Note**: Depending on your OS (specifically Mac and Linux), after you've extracted the files, `.htaccess` may appear hidden by your file manager.
 
@@ -95,6 +117,8 @@ Additionally, you'll need to either add `fastcgi_param PICO_URL_REWRITING 1;` to
 ## Configuring Pico
 
 Pico is ready to go, right out of the box.  However, unless you want your website to be called "Pico", there's at least one configuration option you'll want to set.
+
+{% include gallery.html gallery='standalone_2' %}
 
 To configure Pico, start by navigating to the `config` directory and copying/moving Pico's included `config.php.template` to `config.php`.
 


### PR DESCRIPTION
This PR is a continuation of the ideas in https://github.com/picocms/Pico/pull/359.  With the new website repo, this needed a new PR, not to mention that it shares no code with the original branch I was using.

For quicker reference, here is the relevant content from https://github.com/picocms/Pico/pull/359:

>The idea here is going to be a full (or close to) rewrite of the existing Documentation into smaller, more in-depth pages.
>
>Since the plan is to redesign the docs around this new style, it'll only really be merge-able when _all_ the work is done.  For this reason I've decided to make it one PR and not do a PR per-page.  If this changes, or I write a decent, standalone page, we can always merge them in on a case-by-case basis.
>
>Discussion on this topic was previously started on #352.
>
>Here's some quotes from that thread:
>- Page Topics
>
>> - An "Installing Pico" page that covers, in-depth, the concepts of installing and configuring Pico, your webserver (well, links to external resources anyway) and etc. Everything up until you're looking at Pico's sample content.
>> - A "Creating Content" page that goes over YAML and Markdown.
>>   Perhaps a general, "Usage" type page that covers things like how URLs work, how to lay out and organize your website, separating content and assets, more about config options, etc.
>> - Customization: An in-depth guide to installing community themes, creating your own, understanding Twig, Pico variables, everything. Not plugins though.
>> - A separate page for Plugins (and plugin development).
>> - Maybe a combination of "Getting Help" and "Contributing" (or "Getting Involved"). It should be a generally community-focused page. On that note, I think it would be great if we eventually had a place for non-development, non-bug related community discussions. I don't want to say a "forum" because that feels like a really outdated notion, but a "place" to develop a community nonetheless.
>- Table of Contents
>
>> When on the Overview Page:
>> 
>> ```
>> * Installing Pico
>> * Creating Content
>> * Customization
>> * Getting Help
>> ```
>> 
>> When on Creating Content Page:
>> 
>> ```
>> * Installing Pico
>> * Creating Content
>>    * YAML
>>    * Markdown
>>    * Etc
>> * Customization
>> * Getting Help
>> ```
>
>---
>- Advanced asset handling guide https://github.com/picocms/Pico/pull/368#issuecomment-243415712
>- Definition Lists for Twig Terms https://github.com/picocms/Pico/pull/358#discussion_r83863940

These WIP pages contain commented sections at the end that are from their original incarnations in the Docs.  This is content that I've cut from the page and/or not yet reworked.

The current WIP state can be previewed here:
* [Installing](https://smcdougall.github.io/picocms.github.io/docs/installing/)
* [Creating Content](https://smcdougall.github.io/picocms.github.io/docs/creating-content/)