### PR TITLE
Plugin submission: Comments for Pico

### DIFF
--- a/_plugins/comments.md
+++ b/_plugins/comments.md
@@ -1,0 +1,21 @@
+---
+heading: Comments
+categories:
+  - utility
+description: Let users add comments to your pages.
+link: https://github.com/push-eax/pico-comments
+info:
+  By: "[push-eax](https://kiernanro.ch)"
+  License: "[MIT](https://github.com/push-eax/pico-comments/blob/master/LICENSE)"
+---
+
+This plugin implements comments for Pico CMS.
+
+**Features**:
+- Comments are stored in a similar manner to pages as flat files
+- Comment replies
+- Comment review
+- Comment size limits
+- Antispam using a honeypot form field
+- IP address logging
+- Theoretically scalable


### PR DESCRIPTION
I've written a comments plugin for Pico. Many people are using Pico for blogging and I want to make page comments available to them.

There is a detailed explanation of my design decisions in the README of the plugin repo, so please refer to that (and the code itself) first and I can clarify if necessary.

Thanks.