### PR TITLE
Change position of buttons on plugins page

### DIFF
--- a/style.css
+++ b/style.css
@@ -1067,7 +1067,7 @@ ul.contact-info li i {
 .items li div.button-like {
     opacity: 0;
     position: absolute;
-    top: 60%;
+    top: 70%;
     left: 50%;
     margin-left: -63.5px;
 }

--- a/style.css
+++ b/style.css
@@ -1067,7 +1067,7 @@ ul.contact-info li i {
 .items li div.button-like {
     opacity: 0;
     position: absolute;
-    top: 39%;
+    top: 60%;
     left: 50%;
     margin-left: -63.5px;
 }


### PR DESCRIPTION
<!--

Developer Certificate of Origin
===============================

By contributing to Pico, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to Pico. Please refer to the *Developer Certificate of Origin* section in Pico's [`CONTRIBUTING.md`](https://github.com/picocms/Pico/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

-->

The position of the buttons on the [plugins badges](https://picocms.org/plugins/) is overlapping with the plugin text.

Before:
![image](https://user-images.githubusercontent.com/94064167/236618694-8ef83365-3d14-4788-8737-b979d591ba85.png)

After:
![image](https://user-images.githubusercontent.com/94064167/236618617-e42c16c8-3255-4859-b309-fa3677a4d3b0.png)
