### PR TITLE
Code Example was not compatible with new Twig version 3

### DIFF
--- a/_docs/creating-content.md
+++ b/_docs/creating-content.md
@@ -108,12 +108,14 @@ If you want to use Pico as a blogging software, you probably want to do somethin
     <li>
         Create the new Twig template <code>blog-index.twig</code> (the file name must match the <code>Template</code> meta header from Step 2) in your theme directory. This template probably isn't very different from your default <code>index.twig</code> (i.e. copy <code>index.twig</code>), it will create a list of all your blog articles. Add the following Twig snippet to <code>blog-index.twig</code> near <code>{% raw %}{{ content }}{% endraw %}</code>:
 
-{% raw %}<pre><code>{% for page in pages(&quot;blog&quot;)|sort_by(&quot;time&quot;)|reverse if not page.hidden %}
-    &lt;div class=&quot;post&quot;&gt;
-        &lt;h3&gt;&lt;a href=&quot;{{ page.url }}&quot;&gt;{{ page.title }}&lt;/a&gt;&lt;/h3&gt;
-        &lt;p class=&quot;date&quot;&gt;{{ page.date_formatted }}&lt;/p&gt;
-        &lt;p class=&quot;excerpt&quot;&gt;{{ page.description }}&lt;/p&gt;
-    &lt;/div&gt;
+{% raw %}<pre><code>{% for page in pages(&quot;blog&quot;)|sort_by(&quot;time&quot;)|reverse %}
+    {% if not page.hidden %}
+        &lt;div class=&quot;post&quot;&gt;
+            &lt;h3&gt;&lt;a href=&quot;{{ page.url }}&quot;&gt;{{ page.title }}&lt;/a&gt;&lt;/h3&gt;
+            &lt;p class=&quot;date&quot;&gt;{{ page.date_formatted }}&lt;/p&gt;
+            &lt;p class=&quot;excerpt&quot;&gt;{{ page.description }}&lt;/p&gt;
+        &lt;/div&gt;
+    {% endif %}
 {% endfor %}</code></pre>{% endraw %}
     </li>
 </ol>


### PR DESCRIPTION
Under Pico-30:  PHP message: PHP Fatal error:  Uncaught Twig\Error\SyntaxError: Unexpected token "name" of value "if" ("end of statement block" expected).
<!--

Developer Certificate of Origin
===============================

By contributing to Pico, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to Pico. Please refer to the *Developer Certificate of Origin* section in Pico's [`CONTRIBUTING.md`](https://github.com/picocms/Pico/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

-->
